### PR TITLE
fix: cards break layout on mobile screens

### DIFF
--- a/astro-version/src/components/RecipeProperties.astro
+++ b/astro-version/src/components/RecipeProperties.astro
@@ -33,7 +33,7 @@ const formattedProperties = propertiesConfig
   {
     formattedProperties.map(({ name, value }) => (
       <div class="property">
-        <Icon {name} />
+        <Icon class="icon" {name} />
         {value}
       </div>
     ))
@@ -44,11 +44,16 @@ const formattedProperties = propertiesConfig
   .properties {
     display: flex;
     gap: 9px;
+    flex-wrap: wrap;
   }
 
   .property {
     display: flex;
     align-items: center;
     gap: 4px;
+  }
+
+  .icon {
+    flex-shrink: 0;
   }
 </style>

--- a/astro-version/src/layouts/Settings.astro
+++ b/astro-version/src/layouts/Settings.astro
@@ -67,7 +67,7 @@ const messages = settingsMessages(Astro.currentLocale)
 <style>
   .settings {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    grid-template-columns: repeat(auto-fill, var(--card-width));
     gap: 1em;
     margin-bottom: 2em;
   }

--- a/astro-version/src/pages/[lang]/index.astro
+++ b/astro-version/src/pages/[lang]/index.astro
@@ -71,7 +71,7 @@ export const getStaticPaths = (async () => [
 
   .recipes {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    grid-template-columns: repeat(auto-fill, var(--card-width));
     gap: 32px;
   }
 </style>

--- a/astro-version/src/pages/[lang]/recipes/[method].astro
+++ b/astro-version/src/pages/[lang]/recipes/[method].astro
@@ -56,7 +56,7 @@ export const getStaticPaths = (async () => {
 
   .recipes {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    grid-template-columns: repeat(auto-fill, var(--card-width));
     gap: 32px;
     padding-block-end: 24px;
   }

--- a/astro-version/src/styles/common.css
+++ b/astro-version/src/styles/common.css
@@ -4,6 +4,8 @@
   --space-s: 16;
   --space-m: 24;
   --space-l: 48;
+
+  --card-width: minmax(min(100%, 360px), 1fr);
 }
 
 *,


### PR DESCRIPTION
We can add horizontal scroll, but we don't have that much information and it's easier to shrink cards

The narrowest Galaxy Fold shit
![Screenshot from 2024-04-21 18-35-42](https://github.com/OdinVerst/trybrew/assets/15820496/f112545d-ee3e-4c80-806f-f5175dd9c56a)
